### PR TITLE
트리 기능이 존재하는 CardGrid 만들기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
+        "recoil": "^0.7.5",
         "web-vitals": "^2.1.4"
       }
     },
@@ -8783,6 +8784,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -14519,6 +14525,25 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.5.tgz",
+      "integrity": "sha512-GVShsj5+M/2GULWBs5WBJGcsNis/d3YvDiaKjYh3mLKXftjtmk9kfaQ8jwjoIXySCwn8/RhgJ4Sshwgzj2UpFA==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/recursive-readdir": {
@@ -23396,6 +23421,11 @@
         "duplexer": "^0.1.2"
       }
     },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -27367,6 +27397,14 @@
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "recoil": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.5.tgz",
+      "integrity": "sha512-GVShsj5+M/2GULWBs5WBJGcsNis/d3YvDiaKjYh3mLKXftjtmk9kfaQ8jwjoIXySCwn8/RhgJ4Sshwgzj2UpFA==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "recursive-readdir": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
+    "recoil": "^0.7.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -3,13 +3,15 @@ import { AppBar, IconButton, Toolbar, Typography } from "@mui/material"
 import GitHubIcon from "@mui/icons-material/GitHub"
 import { Navigate, Route, Routes } from "react-router-dom"
 import './App.css';
-
+import {
+  RecoilRoot,
+} from 'recoil';
 import Main from "./page/Main/Main"
 import User from "./page/User/User"
 
 function App() {
   return (
-    <>
+    <RecoilRoot>
       <AppBar position='static'>
         <Toolbar>
           <IconButton>
@@ -33,7 +35,7 @@ function App() {
           <Route path="*" element={<Navigate to="/" />}></Route>
         </Routes>
       </div>
-    </>
+    </RecoilRoot>
   );
 }
 

--- a/src/components/UserGrid/UserGrid.jsx
+++ b/src/components/UserGrid/UserGrid.jsx
@@ -2,76 +2,12 @@ import React, { useEffect, useState } from "react";
 import { Grid } from "@mui/material"
 import UserItem from "../UserItem/UserItem"
 import userList from "../../data/emotion.json"
+import { filterEmotionListState } from "../../state"
+import {useRecoilValue} from "recoil"
 function UserGrid() {
-    let users = userList
-    const [currentUsers, setCurrentUsers] = useState([])
-    useEffect(() => {
-        if (!users) return
-        users = setEmotionColor(users)
-        const filter = filterUsers(users)
-        setCurrentUsers(filter)
-    }, [])
-    const color = {
-        anger: "C90000",
-        sad: "5853ea",
-        anxious: "f29661",
-        hurt: "7c7a7a",
-        embarrassed: "934689",
-        happy: "ffd602",
-        love: "ef96ab",
-        wish: "bfd84e",
-    }
-    /*
-    * 1레벨만 필터링함
-    */
-    const filterUsers = (users) => {
-        const filterUsers = []
-        for (const el of users) {
-            if (el.level == "1") {
-                filterUsers.push(el)
-            }
-        }
-        return filterUsers
-    }
-    /**
-     * 16진수 코드표를 받아서 조금 연하게 변경함
-     */
-    const setEmotionColor = (users) => {
-        for (var i in users) {
-            const el = users[i]
-            let [r, g, b] = [color[el.type].substr(0, 2), color[el.type].substr(2, 2), color[el.type].substr(4, 2)]
-            r = (parseInt(r, 16) + (10 * el.index)) > 255 ? "FF" : ("00" + (parseInt(r, 16) + (10 * el.index)).toString(16)).slice(-2)
-            g = (parseInt(g, 16) + (10 * el.index)) > 255 ? "FF" : ("00" + (parseInt(g, 16) + (10 * el.index)).toString(16)).slice(-2)
-            b = (parseInt(b, 16) + (10 * el.index)) > 255 ? "FF" : ("00" + (parseInt(b, 16) + (10 * el.index)).toString(16)).slice(-2)
-            users[i].color = "#" + r + g + b
-        }
-        return users
+    let users = useRecoilValue(filterEmotionListState)
+    console.log(users)
 
-    }
-    const handleUserClick = (type, state) => {
-        const viewUser = []
-        for (const i in users) {
-            if (users[i].type === type) {
-                viewUser.push(users[i])
-            }
-        }
-        if (state) {
-            for (const i in currentUsers) {
-                if (currentUsers[i].type === type) {
-                    currentUsers.splice(i, 1, ...viewUser)
-                    break;
-                }
-            }
-        } else {
-            for (const i in currentUsers) {
-                if (currentUsers[i].type === type) {
-                    currentUsers.splice(parseInt(i) + 1, 9)
-                    break;
-                }
-            }
-        }
-        setCurrentUsers([...currentUsers])
-    }
     return (
         <>
             <Grid
@@ -82,9 +18,9 @@ function UserGrid() {
 
             >
                 {
-                    currentUsers.map((user, index) => (
+                    users.map((user, index) => (
                         <Grid style={{ width: "33.333333%" }} item md={1} sm={1} key={index}>
-                            <UserItem user={user} handleUserClick={handleUserClick} />
+                            <UserItem user={user} />
                         </Grid>
                     ))
                 }

--- a/src/components/UserItem/UserItem.jsx
+++ b/src/components/UserItem/UserItem.jsx
@@ -1,24 +1,29 @@
 import React, { useState } from "react";
-import { 
+import { useRecoilState } from "recoil"
+import { filterState } from "../../state"
+import {
   Card,
   CardContent,
   Avatar,
   Typography,
 } from "@mui/material"
-function UserItem( { user: {type, level, detail, index ,color},handleUserClick} ) {
-  const [cardState, setCardSate] = useState(true)
+function UserItem({ user: { type, level, detail, index, color } }) {
+  const [filter,setFilter] = useRecoilState(filterState);
+
   const handleCardClick = () => {
-    console.log(index)
-    if(index==="1"){
-      var aaa = ""
-      handleUserClick(type,cardState,index)
-      setCardSate(!cardState)  
+    if (index === '1') {
+      console.log(filter)
+      const flag = !filter[type]
+      setFilter({
+        ...filter,
+        [type]:flag
+      })
     }
   }
   return (
-    <Card style={{backgroundColor:color, margin:"2px"}} onClick={handleCardClick}>
-      <CardContent sx={{margin:"auto"}}>
-        <Typography sx={{textAlign:"center"}}>{detail}</Typography>
+    <Card style={{ backgroundColor: color, margin: "2px" }} onClick={handleCardClick}>
+      <CardContent sx={{ margin: "auto" }}>
+        <Typography sx={{ textAlign: "center" }}>{detail}</Typography>
       </CardContent>
     </Card>
   );

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -1,0 +1,62 @@
+import { atom, selector } from "recoil";
+import emotionList from "../data/emotion.json"
+/**
+ * 16진수 코드표를 받아서 조금 연하게 변경함
+ */
+ const setEmotion = (users) => {
+    const color = {
+        anger: "C90000",
+        sad: "5853ea",
+        anxious: "f29661",
+        hurt: "7c7a7a",
+        embarrassed: "934689",
+        happy: "ffd602",
+        love: "ef96ab",
+        wish: "bfd84e",
+    }
+
+    for (var i in users) {
+        const el = users[i]
+        let [r, g, b] = [color[el.type].substr(0, 2), color[el.type].substr(2, 2), color[el.type].substr(4, 2)]
+        r = (parseInt(r, 16) + (10 * el.index)) > 255 ? "FF" : ("00" + (parseInt(r, 16) + (10 * el.index)).toString(16)).slice(-2)
+        g = (parseInt(g, 16) + (10 * el.index)) > 255 ? "FF" : ("00" + (parseInt(g, 16) + (10 * el.index)).toString(16)).slice(-2)
+        b = (parseInt(b, 16) + (10 * el.index)) > 255 ? "FF" : ("00" + (parseInt(b, 16) + (10 * el.index)).toString(16)).slice(-2)
+        users[i].color = "#" + r + g + b
+        users[i].isFold = el.level==="1"
+    }
+    return users
+
+}
+const setFilter = () => {
+    const filter = {}
+    const list = emotionList.filter( (item)=> item.level==="1")
+    for( const el of list){
+        filter[el.type] = false
+    }
+    return filter
+}
+
+const foldEmotion = (level,foldtype,type) => {
+    if(level === "1" || foldtype[type])
+        return true
+    else
+        return false
+}
+export const emotionListState = atom({
+    key: 'emotionListState', // unique ID (with respect to other atoms/selectors)
+    default: setEmotion(emotionList), // default value (aka initial value)
+});
+export const filterState = atom({
+    key: 'filterState', // unique ID (with respect to other atoms/selectors)
+    default: setFilter()
+});
+export const filterEmotionListState = selector({
+    key: 'filterEmotionListState',
+    get: ({ get }) => {
+        const list = get(emotionListState);
+        const filter = get(filterState)
+        console.log(get(emotionListState))
+        return list.filter((item) => foldEmotion(item.level, filter, item.type));
+        // return list
+    },
+});


### PR DESCRIPTION
출퇴근 할때 빠르고 쉽게 일기를 쓰기위해 speedJournal 이라는 프로젝트를 만들었다.
 
오늘의 아침 기분은 ---- 했다.
오늘의 점심 기분은 ---- 했다.
오늘의 저녁 기분은 ---- 했다.
 
라는 문장을 빠르게 완성하기 위한 컴포넌트가 필요했다.
![image](https://user-images.githubusercontent.com/20009315/186390495-b351072d-f84d-41fe-b819-3beffe45a6ff.png)
$

각 감정(emotion)을 클릭하면 문장이 채워질 것이다.
단, 감정의 종류는 다양하기 때문에 아래와 같이 각 핵심 감정(category)을 클릭하면 선택할 수 있는 하위레벨의 감정이 표시된다.
![image](https://user-images.githubusercontent.com/20009315/186390559-3ac07873-3984-44cf-9c04-b1c132eca100.png)
$
 
 
 
이러한 감정들을 json으로 가져온다(추후 mongodb와 연동할 것임)
![image](https://user-images.githubusercontent.com/20009315/186390644-9707b92d-bdfa-4025-95da-40a3595ce90a.png)
$
 
 
 
컴포넌트의 구조는 아래와 같다.
![image](https://user-images.githubusercontent.com/20009315/186390822-27c4c05c-967e-47bf-ad27-f56b231fba73.png)

저널 : 몇번의 터치로 완성될 문장들의 집합(일기)카테고리 그리드 : 각 카테고리를 목록으로 가진 컴포넌트    카테고리 아이템 : 각각의 카테고리
 
 
 
이때 카테고리 아이템은 emotion의 갯수만큼 순회한다.
![image](https://user-images.githubusercontent.com/20009315/186390887-6ebae397-a4d9-437c-a3c4-01caac1f7f52.png)

 

emotion 데이터에서 가져온 아래와 같은 데이터를 card 컴포넌트의 prop으로 가져와 필요한 부분에 셋팅한다.
![image](https://user-images.githubusercontent.com/20009315/186390986-0f309891-3841-441e-aa59-1df2de1209be.png)

대충 컴포넌트는 여기서 마무리.
 
 
 
 
 
 
이제 state를 작성해줘야하는데 recoil의 state는 아래와 같이 하나의 파일에서 관리할 수 있다.
![image](https://user-images.githubusercontent.com/20009315/186391080-ebd6eb57-f466-4f09-9b1d-af1f67968e0f.png)

 
각 state는 key, default로 구성할 수 있는데,
이름 그대로의 의미다.
key는 컴포넌트에서 불러올때, default는 초기값
 
selector는 파생된 상태를 말한다.
예를들어 다른 상태를 가져와 가공하여 get으로 다시 리턴할 수 있고, 
마찬가지로 set으로 변경할 수 있다.
 
filterCategoryListState는 
CategoryList를 filterState의 값에 따라 필터링하여 리턴해준다.
 
예를들어 내가 'sad' 카테고리를 클릭하면 sad에 해당하는 모든 감정을 비활성화하도록 상태가 수정된다.
 
 
 
react는 기본적으로 부모 -> 자식으로만 상태가 변경되기 때문에 클릭 이벤트 등으로 자식-> 부모로 데이터를 전달하려고 할때 코드가 굉장히 지저분해지는데, recoil을 사용하면 하나의 공용 store에서 state를 관리하기때문에 코드가 간결해진다.
 
이전에 작업한 기존 컴포넌트는 상태를 컴포넌트마다 관리하여 코드가 지저분하고 각 카드별 상태를 수정하는게 어려웠는데,recoil을 도입하여 하나의 파일에서 emotion list를 관리하고, 각 컴포넌트에서 상태변화에 따른 랜더링만 집중할 수 있었다.
